### PR TITLE
feat/2006: aws배포를 위한 설정파일 생성

### DIFF
--- a/.ebextensions/03_ffmpeg_package.config
+++ b/.ebextensions/03_ffmpeg_package.config
@@ -1,0 +1,17 @@
+packages:
+  yum:
+    ImageMagick: []
+    ImageMagick-devel: []
+commands:
+  01-wget:
+    command: "wget -O /tmp/ffmpeg.tar.xz https://www.johnvansickle.com/ffmpeg/old-releases/ffmpeg-3.4.2-64bit-static.tar.xz"
+  02-mkdir:
+    command: "if [ ! -d /opt/ffmpeg ] ; then mkdir -p /opt/ffmpeg; fi"
+  03-tar:
+    command: "tar xvf /tmp/ffmpeg.tar.xz -C /opt/ffmpeg"
+  04-ln:
+    command: "if [[ ! -f /usr/bin/ffmpeg ]] ; then ln -sf /opt/ffmpeg/ffmpeg-3.4.2-64bit-static/ffmpeg /usr/bin/ffmpeg; fi"
+  05-ln:
+    command: "if [[ ! -f /usr/bin/ffprobe ]] ; then ln -sf /opt/ffmpeg/ffmpeg-3.4.2-64bit-static/ffprobe /usr/bin/ffprobe; fi"
+  06-pecl:
+    command: "if [ `pecl list | grep imagick` ] ; then pecl install -f imagick; fi"

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+unsafe-perm=true

--- a/views/error.ejs
+++ b/views/error.ejs
@@ -1,3 +1,0 @@
-<h1><%= message %></h1>
-<h2><%= error.status %></h2>
-<pre><%= error.stack %></pre>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,1 +1,0 @@
-<h1>this is / page</h1>


### PR DESCRIPTION
## 개요

- 배포에서 상당히 많은 에러가 발생하였다.
- - 처음 발생한 에러는 아래와 같은 에러였다.
    
    ```jsx
    Jul 14 11:29:55 ip-172-31-14-116 web: Server running at http://127.0.0.1:8080/
    Jul 14 11:36:18 ip-172-31-14-116 web: > smartfit-server@0.0.0 start
    Jul 14 11:36:18 ip-172-31-14-116 web: > node ./bin/www
    Jul 14 11:36:19 ip-172-31-14-116 web: /var/app/current/node_modules/@ffmpeg-installer/ffmpeg/index.js:42
    Jul 14 11:36:19 ip-172-31-14-116 web: throw 'Could not find ffmpeg executable, tried "' + npm3Binary + '", "' + npm2Binary + '" and "' + topLevelBinary + '"';
    Jul 14 11:36:19 ip-172-31-14-116 web: ^
    Jul 14 11:36:19 ip-172-31-14-116 web: Could not find ffmpeg executable, tried "/var/app/current/node_modules/@ffmpeg-installer/linux-x64/ffmpeg", "/var/app/current/node_modules/@ffmpeg-installer/ffmpeg/node_modules/@ffmpeg-installer/linux-x64/ffmpeg" and "/var/app/current/node_modules/@ffmpeg-installer/linux-x64/ffmpeg"
    Jul 14 11:36:19 ip-172-31-14-116 web: (Use `node --trace-uncaught ...` to show where the exception was thrown)
    ```
    
    - 이 에러의 이유를 찾아보니 내가 사용하는 node.js용 ffmpeg는 npm으로 로컬에 설치가 아니라 사용할 때 마다 불러와서 사용하는 방식이라고 한다. 백엔드 코드를 보면 
    const ffmpegPath = require('@ffmpeg-installer/ffmpeg').path;
    이와 같이 .path가 뒤에 붙어있는데 이는 node_modules에 다운로드 받아져 있는 파일의 경로이다. 이를 불러내서 사용하려고 
    ffmpeg.setFfmpegPath(ffmpegPath);
    이와 같은 코드를 사용하는 것이었다… npm install이 무조건 설치하는 것은 아니라는 것을 이번에 알았다.
    - 이를 위해 aws서버에 처음 업로드할 때 aws자체의 리눅스 서버에 ffmpeg를 다운로드 해 주어야했다. 방법은 크게 두 가지가 있었다.
        - eb에 같이 업로드 한 node_modules의 ffmpeg 폴더에 리눅스버전 파일을 같이 업로드한다.
            - 이를 위해 다음과 같은 명령어를 사용해서 node_modules에 리눅스버전 ffmpeg를 설치해주었다.
            npm install @ffmpeg-installer/linux-x64 --force
            결과적으로 ffmpeg에 대한 문제는 해결되었지만 이후에 발생한 다른 문제때문에 이 방법은 무용지물이 되었다.
        - aws가 인식할 수 있는 파일을 프로젝트에 같이 넣어줘서 설치한다.
            - 이를 위해 smartfit-server 루트폴더에 .ebextensions 폴더를 생성하고 해당 폴더 내부에 03_ffmpeg_package.config 파일을 만들어서 내부에 설정파일을 넣어주는 것으로 해결하였다.
            - eb가 처음 구동될 떄 .ebextensions 폴더가 있으면 해당 폴더에 대한 내용을 우선적으로 실행시켜주는 듯 하다.
- 두 번째 에러는 canvas에 대한 에러였다.
node-canvas는 운영체제의 버전에 대해 매우 민감한 패키지였다. 따라서 mac의 arm64버전으로 설치 된 내 node_modulse의 canvas는 리눅스버전의 aws서버에서 돌아가지 않는 것이었다. 에러의 내용은 다음과 같았다.
    
    ```jsx
    Jul 15 08:22:08 ip-172-31-0-71 web: > smartfit-server@0.0.0 start /var/app/current
    Jul 15 08:22:08 ip-172-31-0-71 web: > node ./bin/www
    Jul 15 08:22:09 ip-172-31-0-71 web: internal/modules/cjs/loader.js:1122
    Jul 15 08:22:09 ip-172-31-0-71 web: return process.dlopen(module, path.toNamespacedPath(filename));
    Jul 15 08:22:09 ip-172-31-0-71 web: ^
    Jul 15 08:22:09 ip-172-31-0-71 web: Error: /var/app/current/node_modules/canvas/build/Release/canvas.node: invalid ELF header
    Jul 15 08:22:09 ip-172-31-0-71 web: at Object.Module._extensions..node (internal/modules/cjs/loader.js:1122:18)
    Jul 15 08:22:09 ip-172-31-0-71 web: at Module.load (internal/modules/cjs/loader.js:928:32)
    Jul 15 08:22:09 ip-172-31-0-71 web: at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    Jul 15 08:22:09 ip-172-31-0-71 web: at Module.require (internal/modules/cjs/loader.js:952:19)
    Jul 15 08:22:09 ip-172-31-0-71 web: at require (internal/modules/cjs/helpers.js:88:18)
    Jul 15 08:22:09 ip-172-31-0-71 web: at Object.<anonymous> (/var/app/current/node_modules/canvas/lib/bindings.js:3:18)
    Jul 15 08:22:09 ip-172-31-0-71 web: at Module._compile (internal/modules/cjs/loader.js:1063:30)
    Jul 15 08:22:09 ip-172-31-0-71 web: at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    Jul 15 08:22:09 ip-172-31-0-71 web: at Module.load (internal/modules/cjs/loader.js:928:32)
    Jul 15 08:22:09 ip-172-31-0-71 web: at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    Jul 15 08:22:09 ip-172-31-0-71 web: npm ERR! code ELIFECYCLE
    Jul 15 08:22:09 ip-172-31-0-71 web: npm ERR! errno 1
    Jul 15 08:22:09 ip-172-31-0-71 web: npm ERR! smartfit-server@0.0.0 start: `node ./bin/www`
    Jul 15 08:22:09 ip-172-31-0-71 web: npm ERR! Exit status 1
    Jul 15 08:22:09 ip-172-31-0-71 web: npm ERR!
    Jul 15 08:22:09 ip-172-31-0-71 web: npm ERR! Failed at the smartfit-server@0.0.0 start script.
    Jul 15 08:22:09 ip-172-31-0-71 web: npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
    Jul 15 08:22:09 ip-172-31-0-71 web: npm ERR! A complete log of this run can be found in:
    Jul 15 08:22:09 ip-172-31-0-71 web: npm ERR!     /home/webapp/.npm/_logs/2022-07-15T08_22_09_491Z-debug.log
    ```
    
    - 에러의 내용이 매우 길지만 가장 주목해야 할 내용은 invalid ELF header이다.
    ELF header는 운영체제에서 node_module을 인식할 때 가장 먼저 읽는 내용인 듯 한데, node-canvas패키지는 이 header에 민감한 패키지였나보다.
    - 위의 에러를 해결하기 위해 aws eb에 node_modules를 설치해 줄 필요가 있었다. 처음에는 무조건 cli를 이용해야 하는 줄 알고 eb의 cli에서 npm install을 하는 방법을 검색하였다.
    - 그러나 aws eb에 파일을 처음 업로드했을 때 node_modules폴더가 없으면 eb가 알아서 npm install을 해준다는 사실을 알게되었다. 따라서 이후에 업로드 할 때는 node_modules파일은 제외하고 업로드 하였다.
    - 위와 같이 조치하고 나니 또 다른 에러가 발생하였다.
    
    ```jsx
    npm ERR! code ELIFECYCLE
    npm ERR! errno 1
    npm ERR! canvas@2.9.3 install: `node-pre-gyp install --fallback-to-build --update-binary`
    npm ERR! Exit status 1
    npm ERR! 
    npm ERR! Failed at the canvas@2.9.3 install script.
    npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
    
    npm ERR! A complete log of this run can be found in:
    npm ERR!     /root/.npm/_logs/2022-07-15T08_11_23_305Z-debug.log
    
    2022/07/15 08:11:23.322450 [ERROR] An error occurred during execution of command [app-deploy] - [Use NPM to install dependencies]. Stop running the command. Error: Command /bin/sh -c npm --production install failed with error exit status 1. Stderr:node-pre-gyp WARN Pre-built binaries not installable for canvas@2.9.3 and node@14.16.0 (node-v83 ABI, glibc) (falling back to source compile with node-gyp) 
    node-pre-gyp WARN Hit error EACCES: permission denied, mkdir '/var/app/staging/node_modules/canvas/build' 
    gyp WARN EACCES current user ("healthd") does not have permission to access the dev dir "/root/.cache/node-gyp/14.16.0"
    gyp WARN EACCES attempting to reinstall using temporary dev dir "/var/app/staging/node_modules/canvas/.node-gyp"
    gyp WARN install got an error, rolling back install
    gyp WARN install got an error, rolling back install
    gyp ERR! configure error 
    gyp ERR! stack Error: EACCES: permission denied, mkdir '/var/app/staging/node_modules/canvas/.node-gyp'
    gyp ERR! System Linux 4.14.281-212.502.amzn2.x86_64
    gyp ERR! command "/opt/elasticbeanstalk/node-install/node-v14.16.0-linux-x64/bin/node" "/opt/elasticbeanstalk/node-install/node-v14.16.0-linux-x64/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "configure" "--fallback-to-build" "--update-binary" "--module=/var/app/staging/node_modules/canvas/build/Release/canvas.node" "--module_name=canvas" "--module_path=/var/app/staging/node_modules/canvas/build/Release" "--napi_version=7" "--node_abi_napi=napi" "--napi_build_version=0" "--node_napi_label=node-v83"
    gyp ERR! cwd /var/app/staging/node_modules/canvas
    gyp ERR! node -v v14.16.0
    gyp ERR! node-gyp -v v5.1.0
    gyp ERR! not ok 
    node-pre-gyp ERR! build error 
    node-pre-gyp ERR! stack Error: Failed to execute '/opt/elasticbeanstalk/node-install/node-v14.16.0-linux-x64/bin/node /opt/elasticbeanstalk/node-install/node-v14.16.0-linux-x64/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js configure --fallback-to-build --update-binary --module=/var/app/staging/node_modules/canvas/build/Release/canvas.node --module_name=canvas --module_path=/var/app/staging/node_modules/canvas/build/Release --napi_version=7 --node_abi_napi=napi --napi_build_version=0 --node_napi_label=node-v83' (1)
    node-pre-gyp ERR! stack     at ChildProcess.<anonymous> (/var/app/staging/node_modules/@mapbox/node-pre-gyp/lib/util/compile.js:89:23)
    node-pre-gyp ERR! stack     at ChildProcess.emit (events.js:315:20)
    node-pre-gyp ERR! stack     at maybeClose (internal/child_process.js:1048:16)
    node-pre-gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:288:5)
    node-pre-gyp ERR! System Linux 4.14.281-212.502.amzn2.x86_64
    node-pre-gyp ERR! command "/opt/elasticbeanstalk/node-install/node-v14.16.0-linux-x64/bin/node" "/var/app/staging/node_modules/.bin/node-pre-gyp" "install" "--fallback-to-build" "--update-binary"
    node-pre-gyp ERR! cwd /var/app/staging/node_modules/canvas
    node-pre-gyp ERR! node -v v14.16.0
    node-pre-gyp ERR! node-pre-gyp -v v1.0.9
    node-pre-gyp ERR! not ok
    ```
    
    - 키워드를 보니 canvas, node-pre-gyp, permission denied 등을 볼 수 있다.
    해당 키워드로 구글링을 해보니 aws에서 npm install을 할 때 특정 패키지들은 안전하지 않다고 판단해서 설치를 막는것으로 보인다.
    - 해당 현상을 해결하기 위해서는 unsafe-perm=true라는 환경변수를 .npmrc파일에 써 줘야한다고 한다. 처음에는 해당 블로그를 보고 .npmrc를 수정해주었지만 실패하였다. 그 이유는 aws에 업로드 한 package.json을 보고 aws서버에서 npm insatll을 해 주어야 하는데 내 로컬에서 .npmrc를 아무리 수정해봤자 aws서버에는 영향이 없는 것이다.
    - 계속 된 구글링을 통해 해결 방법은 aws에 직접 입력하는 것이었는데 이 또한 aws cli로 수행하는 줄 알고 삽질을 많이 했다…
    그러나 .ebextensions와 마찬가지로 .npmrc파일을 프로젝트의 루트폴더에 쓰면 aws에서 npm install을 할 때 자동으로 인식해서 해당 환경변수를 입력시켜준다고 한다.
    - smartfit-server의 루트폴더에 .npmrc파일을 만든 후에 unsafe-perm=true를 입력시켜주니 드디어… canvas도 제대로 설치되고 제대로 서버가 배포되었다….
        
        [[npmrc 파일과 npm config 커맨드](https://www.daleseo.com/js-npm-config/)](https://www.daleseo.com/js-npm-config/)
        
- 세 번째 에러는 firebase에 관련 된 에러였다.
    - 너무나도 기쁜 나머지 동영상 업로드를 해 본 결과.. 실패하였다.
    - 에러의 내용은 다음과 같았다.
    
    ```jsx
    Jul 15 10:12:40 ip-172-31-0-71 web: Error: 16 UNAUTHENTICATED: Failed to retrieve auth metadata with error: error:0909006C:PEM routines:get_name:no start line
    Jul 15 10:12:40 ip-172-31-0-71 web: at Object.callErrorFromStatus (/var/app/current/node_modules/@grpc/grpc-js/build/src/call.js:31:26)
    Jul 15 10:12:40 ip-172-31-0-71 web: at Object.onReceiveStatus (/var/app/current/node_modules/@grpc/grpc-js/build/src/client.js:189:52)
    Jul 15 10:12:40 ip-172-31-0-71 web: at Object.onReceiveStatus (/var/app/current/node_modules/@grpc/grpc-js/build/src/client-interceptors.js:365:141)
    Jul 15 10:12:40 ip-172-31-0-71 web: at Object.onReceiveStatus (/var/app/current/node_modules/@grpc/grpc-js/build/src/client-interceptors.js:328:181)
    Jul 15 10:12:40 ip-172-31-0-71 web: at /var/app/current/node_modules/@grpc/grpc-js/build/src/call-stream.js:187:78
    Jul 15 10:12:40 ip-172-31-0-71 web: at processTicksAndRejections (internal/process/task_queues.js:75:11)
    Jul 15 10:12:40 ip-172-31-0-71 web: Caused by: Error
    Jul 15 10:12:40 ip-172-31-0-71 web: at WriteBatch.commit (/var/app/current/node_modules/@google-cloud/firestore/build/src/write-batch.js:434:23)
    Jul 15 10:12:40 ip-172-31-0-71 web: at DocumentReference.update (/var/app/current/node_modules/@google-cloud/firestore/build/src/reference.js:426:14)
    Jul 15 10:12:40 ip-172-31-0-71 web: at exports.createVideoData (/var/app/current/services/tensorflow.services.js:26:8)
    Jul 15 10:12:40 ip-172-31-0-71 web: at exports.analyzeVideo (/var/app/current/routes/controllers/tensorflow.controllers.js:6:5)
    Jul 15 10:12:40 ip-172-31-0-71 web: at Layer.handle [as handle_request] (/var/app/current/node_modules/express/lib/router/layer.js:95:5)
    Jul 15 10:12:40 ip-172-31-0-71 web: at next (/var/app/current/node_modules/express/lib/router/route.js:137:13)
    Jul 15 10:12:40 ip-172-31-0-71 web: at createTensorData (/var/app/current/middlewares/createTensorData.js:51:5)
    Jul 15 10:12:40 ip-172-31-0-71 web: at processTicksAndRejections (internal/process/task_queues.js:93:5) {
    Jul 15 10:12:40 ip-172-31-0-71 web: code: 16,
    Jul 15 10:12:40 ip-172-31-0-71 web: details: 'Failed to retrieve auth metadata with error: error:0909006C:PEM routines:get_name:no start line',
    Jul 15 10:12:40 ip-172-31-0-71 web: metadata: Metadata { internalRepr: Map(0) {}, options: {} },
    Jul 15 10:12:40 ip-172-31-0-71 web: note: 'Exception occurred in retry method that was not classified as transient'
    Jul 15 10:12:40 ip-172-31-0-71 web: }
    Jul 15 10:12:40 ip-172-31-0-71 web: npm ERR! code ELIFECYCLE
    Jul 15 10:12:40 ip-172-31-0-71 web: npm ERR! errno 7
    Jul 15 10:12:40 ip-172-31-0-71 web: npm ERR! smartfit-server@0.0.0 start: `node ./bin/www`
    Jul 15 10:12:40 ip-172-31-0-71 web: npm ERR! Exit status 7
    Jul 15 10:12:40 ip-172-31-0-71 web: npm ERR!
    Jul 15 10:12:40 ip-172-31-0-71 web: npm ERR! Failed at the smartfit-server@0.0.0 start script.
    Jul 15 10:12:40 ip-172-31-0-71 web: npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
    Jul 15 10:12:40 ip-172-31-0-71 web: npm ERR! A complete log of this run can be found in:
    Jul 15 10:12:40 ip-172-31-0-71 web: npm ERR!     /home/webapp/.npm/_logs/2022-07-15T10_12_40_294Z-debug.log
    ```
    
    - 에러의 키워드를 보니 UNAUTHENTICATED가 눈에 띈다.
    해당 키워드로 검색을 해보니 firestore의 인증시간과 내 서버의 시간차이가 많이 나면 발생하는 문제라고 한다.
    - 아마 윈도우컴퓨터에서 컴퓨너의 로컬시간과 인터넷의 시간차이가 많이 나면 인증을 할 수 없다는 에러와 비슷한 현상같다.
    - 결국 위의 에러는 해결하지 못하고 분석한 값들을 프론트로 response해 줘서 프론트에서 firestore에 저장하는 방식으로 변경하였다.

## 작업사항

- aws 배포를 위해 .npmrc파일과 .ebextensions 설정 추가
